### PR TITLE
Add FIEL handling and cert loading tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # Snp.CFDIDownload
+
+This repository contains a library that illustrates how to interact with the SAT CFDI mass download service. The code targets **.NET Framework 4.8** and includes a small MSTest project.
+
+## Structure
+
+- `src/Snp.CFDIDownload` – class library implementing `CFDIDownloadService`.
+- `test/Snp.CFDIDownload.Tests` – unit tests using `FakeHttpMessageHandler`.
+- `Snp.CFDIDownload.sln` – Visual Studio solution file.
+
+## Building
+
+You will need the .NET SDK or Visual Studio with .NET Framework 4.8 installed.
+From a developer command prompt run:
+
+```bash
+msbuild Snp.CFDIDownload.sln
+```
+
+To execute the tests use MSTest or the `dotnet` CLI:
+
+```bash
+dotnet test Snp.CFDIDownload.sln
+```
+
+These commands require the appropriate tooling installed on your machine.
+
+## Using your FIEL
+
+`CFDIDownloadService` expects the path to your `.cer` and `.key` files plus the
+password protecting the private key. The service combines both files into a
+temporary PFX certificate and signs the authentication request. Ensure the files
+are valid and correspond to the same certificate issued by SAT.

--- a/Snp.CFDIDownload.sln
+++ b/Snp.CFDIDownload.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snp.CFDIDownload", "src\\Snp.CFDIDownload\\Snp.CFDIDownload.csproj", "{4E84C2C3-662C-4EE5-9C0A-76F20D8102C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snp.CFDIDownload.Tests", "test\\Snp.CFDIDownload.Tests\\Snp.CFDIDownload.Tests.csproj", "{08F7EBE0-B075-482A-8F0C-7A4425AD78B9}"
+EndProject
+Global
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Release|Any CPU = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {4E84C2C3-662C-4EE5-9C0A-76F20D8102C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {4E84C2C3-662C-4EE5-9C0A-76F20D8102C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {4E84C2C3-662C-4EE5-9C0A-76F20D8102C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {4E84C2C3-662C-4EE5-9C0A-76F20D8102C2}.Release|Any CPU.Build.0 = Release|Any CPU
+    {08F7EBE0-B075-482A-8F0C-7A4425AD78B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {08F7EBE0-B075-482A-8F0C-7A4425AD78B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {08F7EBE0-B075-482A-8F0C-7A4425AD78B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {08F7EBE0-B075-482A-8F0C-7A4425AD78B9}.Release|Any CPU.Build.0 = Release|Any CPU
+  EndGlobalSection
+EndGlobal

--- a/src/Snp.CFDIDownload/CFDIDownloadService.cs
+++ b/src/Snp.CFDIDownload/CFDIDownloadService.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Org.BouncyCastle.Pkcs;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
+namespace Snp.CFDIDownload
+{
+    /// <summary>
+    /// Simplified implementation of the SAT CFDI mass download service.
+    /// This code illustrates how to perform the authentication and
+    /// download requests using the official SOAP endpoints.
+    /// It does not contain production ready error handling.
+    /// </summary>
+    public class CFDIDownloadService : ICFDIDownloadService
+    {
+        private const string AuthUrl = "https://certificador.sat.gob.mx/usuariosv3";
+        private const string DownloadUrl = "https://descargamasiva.sat.gob.mx/CFDIService";
+        private readonly HttpClient _httpClient;
+
+        public CFDIDownloadService(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
+        public async Task<string> AuthenticateAsync(string rfc, string certificatePath, string privateKeyPath, string privateKeyPassword)
+        {
+            if (string.IsNullOrWhiteSpace(rfc))
+                throw new ArgumentException("RFC is required", nameof(rfc));
+            if (!File.Exists(certificatePath))
+                throw new FileNotFoundException("Certificate file not found", certificatePath);
+            if (!File.Exists(privateKeyPath))
+                throw new FileNotFoundException("Private key file not found", privateKeyPath);
+
+            var cert = LoadFielCertificate(certificatePath, privateKeyPath, privateKeyPassword);
+            var soap = BuildAuthEnvelope(cert, rfc);
+            var content = new StringContent(soap, Encoding.UTF8, "text/xml");
+            using var response = await _httpClient.PostAsync(AuthUrl, content).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var xml = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return ParseAuthToken(xml);
+        }
+
+        public async Task DownloadAsync(string authToken, string outputFolder, string rfc, string startDate, string endDate)
+        {
+            if (string.IsNullOrWhiteSpace(authToken))
+                throw new ArgumentException("Authentication token is required", nameof(authToken));
+            if (!Directory.Exists(outputFolder))
+                Directory.CreateDirectory(outputFolder);
+
+            var soap = BuildDownloadEnvelope(authToken, rfc, startDate, endDate);
+            var content = new StringContent(soap, Encoding.UTF8, "text/xml");
+            using var response = await _httpClient.PostAsync(DownloadUrl, content).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            var zipData = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            var outFile = Path.Combine(outputFolder, $"cfdi_{startDate}_{endDate}.zip");
+            await File.WriteAllBytesAsync(outFile, zipData).ConfigureAwait(false);
+        }
+
+        private static string BuildAuthEnvelope(X509Certificate2 cert, string rfc)
+        {
+            var now = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss");
+            var cadena = $"||{rfc}|{now}||";
+            using var rsa = cert.GetRSAPrivateKey();
+            var sello = Convert.ToBase64String(rsa.SignData(Encoding.UTF8.GetBytes(cadena), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+
+            var encodedCert = Convert.ToBase64String(cert.RawData);
+            var envelope = new XDocument(
+                new XElement("Autenticacion",
+                    new XElement("rfc", rfc),
+                    new XElement("fecha", now),
+                    new XElement("certificado", encodedCert),
+                    new XElement("sello", sello))
+            );
+            return envelope.ToString();
+        }
+
+        private static string ParseAuthToken(string xml)
+        {
+            var doc = XDocument.Parse(xml);
+            var token = doc.Root?.Element("token")?.Value;
+            if (string.IsNullOrWhiteSpace(token))
+                throw new InvalidDataException("Token not present in response");
+            return token;
+        }
+
+        private static string BuildDownloadEnvelope(string token, string rfc, string start, string end)
+        {
+            var envelope = new XDocument(
+                new XElement("SolicitudDescarga",
+                    new XElement("token", token),
+                    new XElement("rfcSolicitante", rfc),
+                    new XElement("fechaInicial", start),
+                    new XElement("fechaFinal", end))
+            );
+            return envelope.ToString();
+        }
+
+        internal static X509Certificate2 LoadFielCertificate(string certificatePath, string keyPath, string password)
+        {
+            var certParser = new X509CertificateParser();
+            var bcCert = certParser.ReadCertificate(File.ReadAllBytes(certificatePath));
+
+            var encInfo = new Pkcs8EncryptedPrivateKeyInfo(File.ReadAllBytes(keyPath));
+            var keyInfo = encInfo.DecryptPrivateKeyInfo(password.ToCharArray());
+            var key = PrivateKeyFactory.CreateKey(keyInfo);
+
+            var store = new Pkcs12Store();
+            var entry = new X509CertificateEntry(bcCert);
+            store.SetCertificateEntry("cert", entry);
+            store.SetKeyEntry("key", new AsymmetricKeyEntry(key), new[] { entry });
+
+            using var ms = new MemoryStream();
+            store.Save(ms, password.ToCharArray(), new SecureRandom());
+            return new X509Certificate2(ms.ToArray(), password, X509KeyStorageFlags.MachineKeySet);
+        }
+    }
+}

--- a/src/Snp.CFDIDownload/ICFDIDownloadService.cs
+++ b/src/Snp.CFDIDownload/ICFDIDownloadService.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace Snp.CFDIDownload
+{
+    /// <summary>
+    /// Defines operations for interacting with the SAT CFDI mass download service.
+    /// </summary>
+    public interface ICFDIDownloadService
+    {
+        /// <summary>
+        /// Authenticates with SAT and returns an authorization token.
+        /// </summary>
+        Task<string> AuthenticateAsync(string rfc, string certificatePath, string privateKeyPath, string privateKeyPassword);
+
+        /// <summary>
+        /// Downloads CFDIs matching the specified query and saves them to the provided folder.
+        /// </summary>
+        Task DownloadAsync(string authToken, string outputFolder, string rfc, string startDate, string endDate);
+    }
+}

--- a/src/Snp.CFDIDownload/Properties/AssemblyInfo.cs
+++ b/src/Snp.CFDIDownload/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Snp.CFDIDownload.Tests")]
+

--- a/src/Snp.CFDIDownload/Snp.CFDIDownload.csproj
+++ b/src/Snp.CFDIDownload/Snp.CFDIDownload.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <RootNamespace>Snp.CFDIDownload</RootNamespace>
+    <AssemblyName>Snp.CFDIDownload</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.9.0" />
+  </ItemGroup>
+</Project>

--- a/test/Snp.CFDIDownload.Tests/CFDIDownloadServiceTests.cs
+++ b/test/Snp.CFDIDownload.Tests/CFDIDownloadServiceTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+using System.Net.Http;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Snp.CFDIDownload;
+
+namespace Snp.CFDIDownload.Tests
+{
+    [TestClass]
+    public class CFDIDownloadServiceTests
+    {
+        [TestMethod]
+        public void CanCreateService()
+        {
+            var service = new CFDIDownloadService(new HttpClient());
+            Assert.IsNotNull(service);
+        }
+
+        [TestMethod]
+        public async Task AuthenticateAsync_ReturnsToken()
+        {
+            var handler = new FakeHttpMessageHandler();
+            handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<response><token>abc</token></response>")
+            });
+            var service = new CFDIDownloadService(new HttpClient(handler));
+            var token = await service.AuthenticateAsync("AAA010101AAA", "cert.pfx", "key.key", "pass");
+            Assert.AreEqual("abc", token);
+        }
+
+        [TestMethod]
+        public void LoadFielCertificate_ReturnsCertificate()
+        {
+            var password = "12345";
+            var certPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".cer");
+            var keyPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".key");
+
+            using (var rsa = RSA.Create(2048))
+            {
+                var req = new CertificateRequest("cn=test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(1));
+                File.WriteAllBytes(certPath, cert.Export(X509ContentType.Cert));
+                var pkcs8 = rsa.ExportEncryptedPkcs8PrivateKey(password, new PbeParameters(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 2048));
+                File.WriteAllBytes(keyPath, pkcs8);
+            }
+
+            var loaded = CFDIDownloadService.LoadFielCertificate(certPath, keyPath, password);
+            Assert.IsTrue(loaded.HasPrivateKey);
+        }
+    }
+}

--- a/test/Snp.CFDIDownload.Tests/FakeHttpMessageHandler.cs
+++ b/test/Snp.CFDIDownload.Tests/FakeHttpMessageHandler.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Snp.CFDIDownload.Tests
+{
+    /// <summary>
+    /// Simple fake HTTP message handler for unit testing.
+    /// </summary>
+    public class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new Queue<HttpResponseMessage>();
+
+        public void QueueResponse(HttpResponseMessage response)
+        {
+            _responses.Enqueue(response);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_responses.Count == 0)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}

--- a/test/Snp.CFDIDownload.Tests/Snp.CFDIDownload.Tests.csproj
+++ b/test/Snp.CFDIDownload.Tests/Snp.CFDIDownload.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Snp.CFDIDownload\Snp.CFDIDownload.csproj" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- sign authentication requests using the FIEL certificate
- add helper to load .cer and .key files into a temporary PFX
- expose internals to tests
- test FIEL certificate loading
- document how to supply FIEL credentials

## Testing
- `dotnet test Snp.CFDIDownload.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68733938d97c8331a63e051a2b3fd1b1